### PR TITLE
typo fixed in date_acquisition

### DIFF
--- a/centaurminer/Engine.py
+++ b/centaurminer/Engine.py
@@ -89,7 +89,7 @@ class MiningEngine:
                 get_func = self.get
             self.results[info] = get_func(element)
         self.results['url'] = url
-        self.results['date_aquisition'] = date.today().strftime("%Y-%m-%d")
+        self.results['date_acquisition'] = date.today().strftime("%Y-%m-%d")
 
     def get_authors(self, element):
         '''


### PR DESCRIPTION
Hey,

Typo fixed in spelling of `date_acquisition` (from `date_aquisition`) in `Engine.py`